### PR TITLE
VLK-4: - implementing 'final'

### DIFF
--- a/lib/vlk/include/vlk/final.h
+++ b/lib/vlk/include/vlk/final.h
@@ -1,0 +1,103 @@
+// ================================================================================================
+//
+// vlk  Vulkan support library to experiment with VULKAN SDK
+//
+// Copyright (C) 2019 Alexander Seifarth
+//
+// This program is free software; you can redistribute it and/or modify it under the terms of the
+// GNU General Public License as published by the Free Software Foundation; either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+// the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with this program;
+// if not, write to the Free Software Foundation,
+//          Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+//
+// ================================================================================================
+#pragma once
+
+#include <functional>
+
+namespace vlk {
+
+    //! \brief Final object to do cleanup tasks when object's dtor is called.
+    //! A 'final' object holds a functor object that will be invoked when its destructor is called.
+    //! Its main use is to do cleanup task at the end of functions:
+    //! \begincode{C++}
+    //! void myfunction() {
+    //!    vlk::final final_cleanup([]() { // cleanup code here // });
+    //!    ....
+    //!    // dtor of final_cleanup called here --> lambda called.
+    //! }
+    //! \endcode
+    //! The second scenario is to use it as cleanup for exceptions to avoid sub-optimal try-catch clauses:
+    //! void my_throwing_function() {
+    //!    vlk::final exception_cleanup([]() { // cleanup when exception occurred here // });
+    //!    ...
+    //!    if ( //some-bad-condition) {
+    //!      throw my_exception();
+    //!    }
+    //!    ....
+    //!    excetpion_cleanup.reset(); // prevent exception cleanup called here when no exception occured
+    //! }
+    class final
+    {
+    public:
+        using functor_type = void();
+
+        //! Creates an empty final object, e.g. one without callable functor.
+        final();
+
+        //! Creates a final object with the functor f callable in its destructor.
+        template<typename F>
+        explicit final(F f);
+        ~final();
+
+        final(final const&) = delete;
+        final& operator=(final const&) = delete;
+
+        //! Deletes the functor stored inside the final object.
+        void reset();
+
+        //! Sets a new functor object f in the final object.
+        template<typename F>
+        void set(F f);
+
+    private:
+        std::function<functor_type> _functor;
+    };
+
+} // namespace vlk
+
+inline
+vlk::final::final()
+    : final{std::function<functor_type>{}}
+{}
+
+template<typename F>
+vlk::final::final(F f)
+    : _functor{f}
+{}
+
+inline
+vlk::final::~final()
+{
+    if (_functor) {
+        _functor();
+    }
+}
+
+template<typename F>
+void vlk::final::set(F f)
+{
+    _functor = f;
+}
+
+inline
+void vlk::final::reset()
+{
+    _functor = decltype(_functor){};
+}

--- a/test/utest/CMakeLists.txt
+++ b/test/utest/CMakeLists.txt
@@ -2,7 +2,9 @@
 find_package(GTest REQUIRED)
 
 set(SRCS
-    log/test-log.cpp)
+    utility/test-log.cpp
+    utility/test-final.cpp
+)
 
 add_executable(utest "${SRCS}")
 

--- a/test/utest/utility/test-final.cpp
+++ b/test/utest/utility/test-final.cpp
@@ -1,0 +1,96 @@
+// ================================================================================================
+//
+// vlk  Vulkan support library to experiment with VULKAN SDK
+//
+// Copyright (C) 2019 Alexander Seifarth
+//
+// This program is free software; you can redistribute it and/or modify it under the terms of the
+// GNU General Public License as published by the Free Software Foundation; either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+// the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with this program;
+// if not, write to the Free Software Foundation,
+//          Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+//
+// ================================================================================================
+#include <gtest/gtest.h>
+#include <vlk/final.h>
+#include <exception>
+
+TEST(final, empty)
+{
+    {
+        vlk::final fin{};
+    }
+}
+
+TEST(final, invoked)
+{
+    bool invoked{false};
+    {
+        vlk::final fin{[&invoked]() {invoked = true;}};
+        ASSERT_FALSE(invoked);
+    }
+    ASSERT_TRUE(invoked);
+}
+
+TEST(final, reset)
+{
+    bool invoked{false};
+    {
+        vlk::final fin{[&invoked]() {invoked = true;}};
+        ASSERT_FALSE(invoked);
+        fin.reset();
+        ASSERT_FALSE(invoked);
+    }
+    ASSERT_FALSE(invoked);
+}
+
+TEST(final, set)
+{
+    bool inv1{false};
+    bool inv2{false};
+    {
+        vlk::final fin{[&inv1]() {inv1 = true;}};
+        ASSERT_FALSE(inv1);
+        ASSERT_FALSE(inv2);
+
+        fin.set([&inv2]() {inv2 = true;});
+        ASSERT_FALSE(inv1);
+        ASSERT_FALSE(inv2);
+    }
+    ASSERT_FALSE(inv1);
+    ASSERT_TRUE(inv2);
+}
+
+TEST(final, exception_thrown)
+{
+    bool inv{false};
+    try {
+        vlk::final fin{[&inv]() {inv = true;}};
+        ASSERT_FALSE(inv);
+        if (!inv) throw std::runtime_error{""};
+        fin.reset();
+    }
+    catch (std::runtime_error e) {
+        ASSERT_TRUE(inv);
+    }
+}
+
+TEST(final, exception_not_thrown)
+{
+    bool inv{false};
+    try {
+        vlk::final fin{[&inv]() {inv = true;}};
+        ASSERT_FALSE(inv);
+        if (inv) throw std::runtime_error{""};
+        fin.reset();
+    }
+    catch (std::runtime_error e) {
+        ASSERT_FALSE(inv);
+    }
+}

--- a/test/utest/utility/test-log.cpp
+++ b/test/utest/utility/test-log.cpp
@@ -27,8 +27,8 @@ TEST(log, simple_logging_warn)
     set_global_log_level(log_level::warning);
     VLK_LOG_WARNING() << "log1";
     VLK_LOG_ERROR() << "log2";
-    VLK_LOG_INFO() << "log" << "3";
-    VLK_LOG_DEBUG() << "log " << "debug";
+    VLK_LOG_INFO() << "utility" << "3";
+    VLK_LOG_DEBUG() << "utility " << "debug";
     VLK_LOG_TRACE() << "trace";
     VLK_LOG_FATAL() << "fatal";
 }


### PR DESCRIPTION
       - unit tests for 'final'
       - renamed utest/log to utest/utility for all utility unit tests
       - implemented final class for efficient RAII patterns